### PR TITLE
add transform option to configure

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -66,3 +66,34 @@ try {
 
 Attaching more debugging information gives you powerful diagnosis across all
 your exceptions.
+
+### Transform
+
+Yeller allows you to transform errors before they are sent to the server.
+This means that you can override e.g. user id, even for exceptions caught
+by Yeller's toplevel exception handler (which uses `window.onerror`).
+
+If you want to prevent errors from reaching Yeller's server
+(e.g. maybe they come from third party scripts on your page),
+then simply return `false` from your transform function.
+
+```javascript
+Yeller.configure({
+  token: 'YOUR_API_TOKEN_HERE',
+  environment: 'production'
+  transform: function (error) {
+    error.message = "my error";
+    error.custom_data = {
+      user: {
+        id: 1
+      }
+    }
+  }
+});
+
+try {
+  // your code here
+} catch(error) {
+  Yeller.report(error, { custom_data: { user_id: user.id }});
+}
+```

--- a/spec/end_to_end/YellerSpec.js
+++ b/spec/end_to_end/YellerSpec.js
@@ -2,11 +2,11 @@ describe("yeller", function () {
   var yeller, transport;
   beforeEach(function () {
     transport = jasmine.createSpy('transport');
-    yeller = new Yeller(transport, {});
 
   });
 
   it("sends an exception", function () {
+    yeller = new Yeller(transport, {});
     try {
       throw "err";
     } catch(err) {
@@ -14,5 +14,90 @@ describe("yeller", function () {
     }
     expect(transport.calls.mostRecent().args[1].type).toBe('Error');
     expect(transport.calls.mostRecent().args[1].message).toBe('err');
+  });
+
+  it("transforms an exception if there is a transform", function () {
+    yeller = new Yeller(transport,
+        {
+          transform: function(error) {
+            error.message = "transformed";
+            return error;
+          }
+        }
+      );
+    try {
+      throw "err";
+    } catch(err) {
+      yeller.report(err);
+    }
+    expect(transport.calls.mostRecent().args[1].type).toBe('Error');
+    expect(transport.calls.mostRecent().args[1].message).toBe('transformed');
+  });
+
+  it("if the transform throws an error, still sends the exception", function () {
+    yeller = new Yeller(transport,
+        {
+          transform: function(error) {
+            error.message = "transformed";
+            throw 'lol';
+          }
+        }
+      );
+    try {
+      throw "err";
+    } catch(err) {
+      yeller.report(err);
+    }
+    expect(transport.calls.mostRecent().args[1].type).toBe('Error');
+    expect(transport.calls.mostRecent().args[1].message).toBe('transformed');
+  });
+
+  it("if the transform returns false, doesn't send the exception", function () {
+    yeller = new Yeller(transport,
+        {
+          transform: function(error) {
+            return false;
+          }
+        }
+      );
+    try {
+      throw "err";
+    } catch(err) {
+      yeller.report(err);
+    }
+    expect(transport.calls.mostRecent()).toBe(undefined);
+  });
+
+  it("if the filter returns true, sends the exception", function () {
+    yeller = new Yeller(transport,
+        {
+          filter: function(error) {
+            return true;
+          }
+        }
+      );
+    try {
+      throw "err";
+    } catch(err) {
+      yeller.report(err);
+    }
+    expect(transport.calls.mostRecent().args[1].type).toBe('Error');
+    expect(transport.calls.mostRecent().args[1].message).toBe('err');
+  });
+
+  it("if the filter returns false, doesn't send the exception", function () {
+    yeller = new Yeller(transport,
+        {
+          filter: function(error) {
+            return false;
+          }
+        }
+      );
+    try {
+      throw "err";
+    } catch(err) {
+      yeller.report(err);
+    }
+    expect(transport.calls.mostRecent()).toBe(undefined);
   });
 });

--- a/src/Yeller.js
+++ b/src/Yeller.js
@@ -109,6 +109,7 @@
     this.ignored_environments = options.ignored_environments || ['development', 'test'];
     this.eventsRemaining = 10;
     this.filter = options.filter;
+    this.transform = options.transform;
   };
 
   Yeller.prototype.report = function (err, options) {
@@ -143,7 +144,16 @@
     if (this.filter && !this.filter(formattedError)) {
       return false;
     }
-    this.transport(this.token, formattedError);
+    if (this.transform) {
+      try {
+      formattedError = this.transform(formattedError);
+      } catch (e) {
+        console.log("Yeller: caught error in transform: " + e);
+      }
+    }
+    if (formattedError) {
+      this.transport(this.token, formattedError);
+    }
     return true;
   };
 


### PR DESCRIPTION
https://github.com/yeller/yeller.js/issues/3#issuecomment-162102625

This adds a transform option to Yeller.configure, which users can use to
change their errors before they are sent to the server. In addition, if you
want to filter out errors here, you can return `false` from the
`transform` function to prevent errors from reaching the server.
